### PR TITLE
限制statsmodels版本

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy
 scipy
-statsmodels
+statsmodels>=0.13.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@
 
 [metadata]
 name = rqrisk
-version = 1.0.8
+version = 1.0.9
 
 [versioneer]
 VCS = git

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,13 @@ setup(
     zip_safe=False,
     classifiers=[
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     description="risk calc"
 )


### PR DESCRIPTION
numpy 从 1.22.0 开始舍弃了 numpy.MachAr 类，statsmodels 在 0.13.1 版本做了兼容